### PR TITLE
Support ArceOS new config system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,12 +148,19 @@ jobs:
     - name: Build c/redis for x86_64-pc-oslab
       run: make PLATFORM=x86_64-pc-oslab A=c/redis FEATURES=driver-ixgbe,driver-ramdisk SMP=4
 
+    - run: make PLATFORM=aarch64-raspi4 defconfig
     - name: Build rust/helloworld for aarch64-raspi4
-      run: make PLATFORM=aarch64-raspi4 A=rust/helloworld
+      run: make PLATFORM=aarch64-raspi4 SMP=4 A=rust/helloworld
     - name: Build rust/fs/shell for aarch64-raspi4
-      run: make PLATFORM=aarch64-raspi4 A=rust/fs/shell FEATURES=driver-bcm2835-sdhci
+      run: make PLATFORM=aarch64-raspi4 SMP=4 A=rust/fs/shell FEATURES=driver-bcm2835-sdhci BUS=mmio
+
+    - run: make PLATFORM=aarch64-bsta1000b defconfig
     - name: Build rust/helloworld for aarch64-bsta1000b
-      run: make PLATFORM=aarch64-bsta1000b A=rust/helloworld
+      run: make PLATFORM=aarch64-bsta1000b SMP=8 A=rust/helloworld
+
+    - run: make PLATFORM=aarch64-phytium-pi defconfig
+    - name: Build rust/helloworld for aarch64-phytium-pi
+      run: make PLATFORM=aarch64-phytium-pi SMP=4 A=rust/helloworld
 
   build-for-std:
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /.vscode
 /.arceos
 /.cargo
+/.axconfig.*
+/.axroot
 .DS_Store
 Cargo.lock
 *.o

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 A ?= rust/helloworld
-AX_ROOT ?= $(PWD)/.arceos
+AX_ROOT ?= $(shell cat .axroot 2>/dev/null)
 
 APP := $(A)
 ifeq ($(filter /%,$(A)),)
@@ -8,12 +8,14 @@ ifeq ($(filter /%,$(A)),)
   endif
 endif
 
+$(if $(V), $(info AX_ROOT: "$(AX_ROOT)"))
+
 all: build
 
-ax_root:
+chaxroot:
 	@./scripts/set_ax_root.sh $(AX_ROOT)
 
-build run justrun debug disasm disk_img clean clean_c: ax_root
+defconfig oldconfig build run justrun debug disasm disk_img clean clean_c:
 	@make -C $(AX_ROOT) A=$(APP) $@
 
 test:
@@ -23,4 +25,4 @@ else
 	@./scripts/app_test.sh
 endif
 
-.PHONY: all ax_root build run justrun debug disasm disk_img clean clean_c test
+.PHONY: all chaxroot defconfig oldconfig build run justrun debug disasm disk_img clean clean_c test

--- a/scripts/get_deps.sh
+++ b/scripts/get_deps.sh
@@ -5,7 +5,4 @@ AX_ROOT=.arceos
 test ! -d "$AX_ROOT" && echo "Cloning repositories ..." || true
 test ! -d "$AX_ROOT" && git clone https://github.com/arceos-org/arceos "$AX_ROOT" --depth=1 || true
 
-echo "Copying Cargo.lock ..."
-cp "$AX_ROOT/Cargo.lock" Cargo.lock
-
 $(dirname $0)/set_ax_root.sh $AX_ROOT

--- a/scripts/set_ax_root.sh
+++ b/scripts/set_ax_root.sh
@@ -11,3 +11,6 @@ mkdir -p .cargo
 sed -e "s|%AX_ROOT%|$AX_ROOT|g" scripts/config.toml.temp > .cargo/config.toml
 
 echo "Set AX_ROOT (ArceOS directory) to $AX_ROOT"
+
+cp "$AX_ROOT/Cargo.lock" Cargo.lock
+echo "$1" > .axroot


### PR DESCRIPTION
This PR is for https://github.com/arceos-org/arceos/pull/214, which makes the following changes:

1. Add command `make defconfig` & `make oldconfig`
2. Add command `make chaxroot AX_ROOT=/path/to/arceos`, so you don't need to add `AX_ROOT=` when run `make` later.