### PR TITLE
feat: add loongarch64 support

### DIFF
--- a/.github/workflows/actions/setup-musl/action.yml
+++ b/.github/workflows/actions/setup-musl/action.yml
@@ -20,7 +20,11 @@ runs:
     shell: bash
     run: |
       MUSL_PATH=${{ inputs.arch }}-linux-musl-cross
-      wget https://musl.cc/${MUSL_PATH}.tgz
+      if [ "${{ inputs.arch }}" = "loongarch64" ]; then
+        wget https://github.com/LoongsonLab/oscomp-toolchains-for-oskernel/releases/download/loongarch64-linux-musl-cross-gcc-13.2.0/loongarch64-linux-musl-cross.tgz
+      else
+        wget https://musl.cc/${MUSL_PATH}.tgz
+      fi
       tar -xf ${MUSL_PATH}.tgz
   - uses: actions/cache/save@v4
     if: steps.cache-musl.outputs.cache-hit != 'true'

--- a/.github/workflows/actions/setup-qemu/action.yml
+++ b/.github/workflows/actions/setup-qemu/action.yml
@@ -25,7 +25,7 @@ runs:
       sudo apt-get update && sudo apt-get install -y ninja-build libslirp-dev libglib2.0-dev
       wget https://download.qemu.org/$QEMU_PATH.tar.xz && tar -xJf $QEMU_PATH.tar.xz
       cd $QEMU_PATH \
-        && ./configure --prefix=$PREFIX --target-list=x86_64-softmmu,riscv64-softmmu,aarch64-softmmu --enable-slirp \
+        && ./configure --prefix=$PREFIX --target-list=x86_64-softmmu,riscv64-softmmu,aarch64-softmmu,loongarch64-softmmu --enable-slirp \
         && make -j > /dev/null 2>&1 \
         && make install
   - uses: actions/cache/save@v4
@@ -44,3 +44,4 @@ runs:
       qemu-system-x86_64 --version
       qemu-system-aarch64 --version
       qemu-system-riscv64 --version
+      qemu-system-loongarch64 --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        arch: [x86_64, riscv64, aarch64]
+        arch: [x86_64, riscv64, aarch64, loongarch64]
         rust-toolchain: [nightly]
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, llvm-tools
-        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
     - uses: Swatinem/rust-cache@v2
     - run: cargo install cargo-binutils
     - run: ./scripts/get_deps.sh
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        arch: [x86_64, riscv64, aarch64]
+        arch: [x86_64, riscv64, aarch64, loongarch64]
         rust-toolchain: [nightly]
     steps:
     - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, llvm-tools
-        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
     - uses: ./.github/workflows/actions/setup-musl
       with:
         arch: ${{ matrix.arch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test CI
 on: [push, pull_request]
 
 env:
-  qemu-version: 8.2.0
+  qemu-version: 9.2.1
 
 jobs:
   app-test:
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        arch: [x86_64, riscv64, aarch64]
+        arch: [x86_64, riscv64, aarch64, loongarch64]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ Download & install [musl](https://musl.cc) toolchains:
 wget https://musl.cc/aarch64-linux-musl-cross.tgz
 wget https://musl.cc/riscv64-linux-musl-cross.tgz
 wget https://musl.cc/x86_64-linux-musl-cross.tgz
+wget https://github.com/LoongsonLab/oscomp-toolchains-for-oskernel/releases/download/loongarch64-linux-musl-cross-gcc-13.2.0/loongarch64-linux-musl-cross.tgz
 # install
 tar zxf aarch64-linux-musl-cross.tgz
 tar zxf riscv64-linux-musl-cross.tgz
 tar zxf x86_64-linux-musl-cross.tgz
+tar zxf loongarch64-linux-musl-cross.tgz
 # exec below command in bash OR add below info in ~/.bashrc
-export PATH=`pwd`/x86_64-linux-musl-cross/bin:`pwd`/aarch64-linux-musl-cross/bin:`pwd`/riscv64-linux-musl-cross/bin:$PATH
+export PATH=`pwd`/x86_64-linux-musl-cross/bin:`pwd`/aarch64-linux-musl-cross/bin:`pwd`/riscv64-linux-musl-cross/bin:`pwd`/loongarch64-linux-musl-cross/bin:$PATH
 ```
 
 ### 2. Build & Run
@@ -55,7 +57,7 @@ make A=path/to/app ARCH=<arch> LOG=<log>
 
 Where `path/to/app` is the relative path to the application.
 
-`<arch>` should be one of `riscv64`, `aarch64`, `x86_64`.
+`<arch>` should be one of `riscv64`, `aarch64`, `x86_64`, `loongarch64`.
 
 `<log>` should be one of `off`, `error`, `warn`, `info`, `debug`, `trace`.
 

--- a/rust/exception/expect_debug_loongarch64.out
+++ b/rust/exception/expect_debug_loongarch64.out
@@ -1,0 +1,21 @@
+smp = 1
+build_mode = release
+log_level = debug
+
+Primary CPU 0 started,
+Found physcial memory regions:
+ .text (READ | EXECUTE | RESERVED)
+ .rodata (READ | RESERVED)
+ .data .tdata .tbss .percpu (READ | WRITE | RESERVED)
+ .percpu (READ | WRITE | RESERVED)
+ boot stack (READ | WRITE | RESERVED)
+ .bss (READ | WRITE | RESERVED)
+ free memory (READ | WRITE | FREE)
+Initialize platform devices...
+Primary CPU 0 init OK.
+Running exception tests...
+Exception(Breakpoint) @ 0x[0-9a-f]\{16\}
+Breakpoint test OK!
+Page fault @ VA:0xdeadbeef, access_flags: WRITE, is_user: false
+Page fault test OK!
+Shutting down...

--- a/rust/exception/src/main.rs
+++ b/rust/exception/src/main.rs
@@ -15,6 +15,8 @@ fn raise_break_exception() {
         asm!("brk #0");
         #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         asm!("ebreak");
+        #[cfg(target_arch = "loongarch64")]
+        asm!("break 0");
     }
     println!("Breakpoint test OK!");
 }

--- a/scripts/app_test.sh
+++ b/scripts/app_test.sh
@@ -20,7 +20,7 @@ END_C="\x1b[0m"
 if [ -z "$ARCH" ]; then
     ARCH=x86_64
 fi
-if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "aarch64" ]; then
+if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "riscv64" ] && [ "$ARCH" != "aarch64" ] && [ "$ARCH" != "loongarch64" ]; then
     echo "Unknown architecture: $ARCH"
     exit $S_FAILED
 fi


### PR DESCRIPTION
The current questions are:

 1. There is no `loongarch64` toolchain in `musl.cc`, so it needs to be downloaded from another source, which will introduce special handling in CI.
 2. The "chicken-and-egg" problem: no matter whether `arceos-app` or `arceos` is updated first, one of the CI checks will fail, requiring special handling.