### PR TITLE
[config] read configuration from exported values instead of envs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
     - name: Check code format
       run: cargo fmt --all -- --check
     - name: Clippy
-      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: cargo clippy --all-features
 
   build-rust-apps:
@@ -39,7 +38,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, llvm-tools
-        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
       with:
         shared-key: cargo-bin-cache
@@ -96,7 +95,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, llvm-tools
-        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: arceos-org/setup-musl@v1
       with:
         arch: ${{ matrix.arch }}
@@ -137,7 +136,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, llvm-tools
-        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat
+        targets: x86_64-unknown-none, aarch64-unknown-none-softfloat
     - uses: arceos-org/setup-musl@v1
       with:
         arch: x86_64
@@ -147,29 +146,30 @@ jobs:
         cache-targets: false
     - run: cargo install cargo-binutils
     - run: ./scripts/get_deps.sh
-
+    - name: Export config path for x86_64-pc-oslab
+      run: echo "CONFIG_PATH=$(pwd)/.arceos/configs/custom/x86_64-pc-oslab.toml" >> $GITHUB_ENV
     - name: Build rust/helloworld for x86_64-pc-oslab
-      run: make PLATFORM=x86_64-pc-oslab A=rust/helloworld
+      run: make PLAT_CONFIG=$CONFIG_PATH A=rust/helloworld
     - name: Build rust/net/httpserver for x86_64-pc-oslab
-      run: make PLATFORM=x86_64-pc-oslab A=rust/net/httpserver FEATURES=driver-ixgbe
+      run: make PLAT_CONFIG=$CONFIG_PATH  A=rust/net/httpserver FEATURES=driver-ixgbe
     - name: Build c/iperf for x86_64-pc-oslab
-      run: make PLATFORM=x86_64-pc-oslab A=c/iperf FEATURES=driver-ixgbe,driver-ramdisk
+      run: make PLAT_CONFIG=$CONFIG_PATH  A=c/iperf FEATURES=driver-ixgbe,driver-ramdisk
     - name: Build c/redis for x86_64-pc-oslab
-      run: make PLATFORM=x86_64-pc-oslab A=c/redis FEATURES=driver-ixgbe,driver-ramdisk SMP=4
+      run: make PLAT_CONFIG=$CONFIG_PATH  A=c/redis FEATURES=driver-ixgbe,driver-ramdisk SMP=4
 
-    - run: make PLATFORM=aarch64-raspi4 defconfig
+    - run: make MYPLAT=axplat-aarch64-raspi defconfig
     - name: Build rust/helloworld for aarch64-raspi4
-      run: make PLATFORM=aarch64-raspi4 SMP=4 A=rust/helloworld
+      run: make MYPLAT=axplat-aarch64-raspi  A=rust/helloworld
     - name: Build rust/fs/shell for aarch64-raspi4
-      run: make PLATFORM=aarch64-raspi4 SMP=4 A=rust/fs/shell FEATURES=driver-bcm2835-sdhci BUS=mmio
+      run: make MYPLAT=axplat-aarch64-raspi A=rust/fs/shell FEATURES=driver-bcm2835-sdhci BUS=mmio
 
-    - run: make PLATFORM=aarch64-bsta1000b defconfig
+    - run: make MYPLAT=axplat-aarch64-bsta1000b defconfig
     - name: Build rust/helloworld for aarch64-bsta1000b
-      run: make PLATFORM=aarch64-bsta1000b SMP=8 A=rust/helloworld
+      run: make MYPLAT=axplat-aarch64-bsta1000b A=rust/helloworld
 
-    - run: make PLATFORM=aarch64-phytium-pi defconfig
+    - run: make MYPLAT=axplat-aarch64-phytium-pi defconfig
     - name: Build rust/helloworld for aarch64-phytium-pi
-      run: make PLATFORM=aarch64-phytium-pi SMP=4 A=rust/helloworld
+      run: make MYPLAT=axplat-aarch64-phytium-pi A=rust/helloworld
 
   build-for-std:
     runs-on: ${{ matrix.os }}
@@ -184,7 +184,6 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
     - name: Build apps for std
-      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: |
         ./scripts/get_deps.sh
         cargo build --all --exclude arceos-display

--- a/c/redis/README.md
+++ b/c/redis/README.md
@@ -269,7 +269,8 @@ MSET (10 keys): 183150.19 requests per second
 
 ## Compile and Run
 
-- `make A=c/redis LOG=error PLATFORM=x86_64-pc-oslab SMP=4 FEATURES=driver-ixgbe,driver-ramdisk IP=10.2.2.2 GW=10.2.2.1`
+- `./scripts/get_deps.sh`
+- `make A=c/redis LOG=error MYPLAT=<path_to_arceos>/configs/custom/x86_64-pc-oslab.toml SMP=4 FEATURES=driver-ixgbe,driver-ramdisk IP=10.2.2.2 GW=10.2.2.1`
 - Copy `redis_x86_64-pc-oslab.elf` to `/boot`, then reboot.
 - Enter `grub` then boot the PC by ArceOS Redis.
 - Connect to ArceOS-Redis server by:

--- a/rust/exception/src/main.rs
+++ b/rust/exception/src/main.rs
@@ -33,7 +33,7 @@ fn raise_page_fault() {
             vaddr, access_flags, is_user
         );
         println!("Page fault test OK!");
-        axhal::misc::terminate();
+        axhal::power::system_off();
     }
 
     let fault_addr = 0xdeadbeef as *mut u8;

--- a/rust/fs/shell/src/cmd.rs
+++ b/rust/fs/shell/src/cmd.rs
@@ -246,10 +246,14 @@ fn do_pwd(_args: &str) {
 fn do_uname(_args: &str) {
     let arch = option_env!("AX_ARCH").unwrap_or("");
     let platform = option_env!("AX_PLATFORM").unwrap_or("");
-    let smp = match option_env!("AX_SMP") {
-        None | Some("1") => "",
-        _ => " SMP",
+    #[cfg(feature = "axstd")]
+    let smp = if std::thread::available_parallelism().unwrap().get() == 1 {
+        ""
+    } else {
+        " SMP"
     };
+    #[cfg(not(feature = "axstd"))]
+    let smp = "";
     let version = option_env!("CARGO_PKG_VERSION").unwrap_or("0.1.0");
     println!(
         "ArceOS {ver}{smp} {arch} {plat}",

--- a/rust/task/affinity/src/main.rs
+++ b/rust/task/affinity/src/main.rs
@@ -9,8 +9,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
 #[cfg(feature = "axstd")]
-use std::os::arceos::api::config::SMP;
-#[cfg(feature = "axstd")]
 use std::os::arceos::api::task::{ax_set_current_affinity, AxCpuMask};
 #[cfg(feature = "axstd")]
 use std::os::arceos::modules::axhal::percpu::this_cpu_id;
@@ -26,7 +24,7 @@ static FINISHED_TASKS: AtomicUsize = AtomicUsize::new(0);
 fn main() {
     println!("Hello, main task!");
     for i in 0..NUM_TASKS {
-        let cpu_id = i % SMP;
+        let cpu_id = i % thread::available_parallelism().unwrap().get();
         thread::spawn(move || {
             // Initialize cpu affinity here.
             #[cfg(feature = "axstd")]

--- a/rust/task/affinity/src/main.rs
+++ b/rust/task/affinity/src/main.rs
@@ -13,7 +13,7 @@ use std::os::arceos::api::config::SMP;
 #[cfg(feature = "axstd")]
 use std::os::arceos::api::task::{ax_set_current_affinity, AxCpuMask};
 #[cfg(feature = "axstd")]
-use std::os::arceos::modules::axhal::cpu::this_cpu_id;
+use std::os::arceos::modules::axhal::percpu::this_cpu_id;
 
 const KERNEL_STACK_SIZE: usize = 0x40000; // 256 KiB
 

--- a/rust/task/irq/src/main.rs
+++ b/rust/task/irq/src/main.rs
@@ -132,6 +132,7 @@ fn main() {
 
     test_yielding();
     test_sleep();
+    #[cfg(feature = "axstd")]
     test_wait_queue();
 
     println!("Task irq state tests run OK!");

--- a/rust/task/priority/src/main.rs
+++ b/rust/task/priority/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
     }
 
     #[cfg(feature = "axstd")]
-    if cfg!(feature = "sched-cfs") && option_env!("AX_SMP") == Some("1") {
+    if cfg!(feature = "sched-cfs") && thread::available_parallelism().unwrap().get() == 1 {
         assert!(
             leave_times[0] > leave_times[1]
                 && leave_times[1] > leave_times[2]

--- a/rust/task/yield/src/main.rs
+++ b/rust/task/yield/src/main.rs
@@ -21,8 +21,10 @@ fn main() {
             thread::yield_now();
 
             let _order = FINISHED_TASKS.fetch_add(1, Ordering::Relaxed);
-            #[cfg(not(feature = "sched-cfs"))]
-            if option_env!("AX_SMP") == Some("1") {
+            #[cfg(feature = "axstd")]
+            if cfg!(not(feature = "sched-cfs"))
+                && thread::available_parallelism().unwrap().get() == 1
+            {
                 assert!(_order == i); // FIFO scheduler
             }
         });

--- a/scripts/app_test.sh
+++ b/scripts/app_test.sh
@@ -51,6 +51,8 @@ function run_and_compare() {
     local actual=$3
 
     echo -ne "    run with \"${BLOD_C}$args${END_C}\": "
+    # Generate the configuration for every test
+    make -C "$ROOT" $args defconfig > /dev/null
     make -C "$ROOT" A="$APP" $args > "$actual" 2>&1
     if [ $? -ne 0 ]; then
         return $S_BUILD_FAILED


### PR DESCRIPTION
This PR is an adaptation of the changes in [axplat_crates](https://github.com/arceos-org/axplat_crates):
1. It use `CPU_NUM` instead of `SMP` to specify number of CPUs.
2. It read the configuration from the exported values instead of environment variables.

And it remove the `aarch64-unknown-none` target in CICD because of https://github.com/arceos-org/arceos/pull/255.